### PR TITLE
✨ Assistive scripts for contributors

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "license": "MIT",
   "version": "0.0.5",
   "description": "Edgelord Solidity snippets.",
+  "scripts": {
+    "powerup": "node scripts/powerup.js"
+  },
   "files": [
     "src/**/*.sol"
   ],

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "version": "0.0.5",
   "description": "Edgelord Solidity snippets.",
   "scripts": {
-    "powerup": "node scripts/powerup.js"
+    "powerup": "node scripts/powerup.js",
+    "rebrand": "node scripts/rebrand.js"
   },
   "files": [
     "src/**/*.sol"

--- a/scripts/config.js
+++ b/scripts/config.js
@@ -1,0 +1,11 @@
+/*«-«-«-«-«-«-«-«-«-«-«-«-«-«-«-«-«-«-«-«-«-«-«-«-«-«-«-«-«-«-*/
+/*                          CONFIGS                           */
+/*-»-»-»-»-»-»-»-»-»-»-»-»-»-»-»-»-»-»-»-»-»-»-»-»-»-»-»-»-»-»*/
+
+const LATEST_SOLIDITY_VERSION = "0.8.24";
+const SRC_DIR = "src";
+
+module.exports = {
+  LATEST_SOLIDITY_VERSION,
+  SRC_DIR,
+};

--- a/scripts/io.js
+++ b/scripts/io.js
@@ -1,0 +1,110 @@
+const fs = require("fs");
+const path = require("path");
+const { SRC_DIR } = require("./config");
+/*«-«-«-«-«-«-«-«-«-«-«-«-«-«-«-«-«-«-«-«-«-«-«-«-«-«-«-«-«-«-*/
+/*                         I/O Helpers                        */
+/*-»-»-»-»-»-»-»-»-»-»-»-»-»-»-»-»-»-»-»-»-»-»-»-»-»-»-»-»-»-»*/
+
+/**
+ * Recursively retrieves a list of Solidity files within a given directory.
+ *
+ * @param {string} directory - The root directory to search for Solidity files. Defaults to SRC_DIR.
+ * @param {string[]} fileList - An optional array to accumulate file paths (used for recursion).
+ * @returns {string[]} An array of Solidity file paths.
+ */
+function getSolidityFiles(directory = SRC_DIR, fileList = []) {
+  const files = fs.readdirSync(directory);
+
+  files.forEach((file) => {
+    const filePath = path.join(directory, file);
+
+    if (fs.statSync(filePath).isDirectory()) {
+      getSolidityFiles(filePath, fileList);
+    } else if (file.endsWith(".sol")) {
+      fileList.push(filePath);
+    }
+  });
+  return fileList;
+}
+
+/**
+ * Shows the updates to be applied as a table.
+ *
+ * @param {Update[]} updates - An array of update objects containing scope, file paths, pattern, and patch.
+ */
+async function showUpdates(updates) {
+  console.log(`${updates.length} update(s) can be automatically applied:`);
+
+  // Friendly table heading.
+  updates = updates.map((update) => ({
+    "Update type": update.scope,
+    File: update.file,
+    // wrap to 100 chars
+    "Current value": truncate(update.from),
+    "Proposed change": truncate(update.to),
+  }));
+
+  // Increasing index so it starts from 1 instead of 0.
+  updates = updates.reduce((acc, u, i) => {
+    acc[i + 1] = u;
+    return acc;
+  }, {});
+
+  console.table(updates);
+}
+
+/**
+ * Prompts the user for confirmation with a yes/no question.
+ *
+ * @param {string} prompt - The question to ask the user.
+ * @returns {Promise<boolean>} A Promise that resolves to true if the user confirms, false otherwise.
+ */
+async function getUserConfirmation(prompt) {
+  const rl = require("readline").createInterface({
+    input: process.stdin,
+    output: process.stdout,
+  });
+
+  const answer = await new Promise((resolve) => {
+    rl.question(`${prompt} (y/n): `, resolve);
+  });
+  rl.close();
+  return answer.toLowerCase() === "y";
+}
+
+/**
+ * Applies updates to specified files.
+ *
+ * @param {Update[]} updates - An array of update objects containing scope, file paths, pattern, and patch.
+ */
+function applyUpdates(updates) {
+  updates.forEach((update) => {
+    let content = fs.readFileSync(update.file, "utf-8");
+    // The update query may contain reserved regex characters
+    // that needs to be escaped to be considered literally.
+    let inputString = update.from.replace(/[-[\]{}()*+?.,\\^$|#\s]/g, "\\$&");
+    content = content.replace(new RegExp(inputString, "g"), update.to);
+    fs.writeFileSync(update.file, content, "utf-8");
+  });
+  console.log(
+    `🎉 ${updates.length} update(s) applied.\n👀 Please verify before committing to git.`
+  );
+}
+/**
+ * Adds ellipis to text beyond a defined length.
+ *
+ * @param {string} Text the text to truncate.
+ * @returns {string} The truncated text.
+ */
+function truncate(text) {
+  let length = 30;
+  if (text.length <= length) return text;
+  return text.substr(0, 30) + "\u2026";
+}
+
+module.exports = {
+  getSolidityFiles,
+  showUpdates,
+  getUserConfirmation,
+  applyUpdates,
+};

--- a/scripts/io.js
+++ b/scripts/io.js
@@ -39,7 +39,6 @@ async function showUpdates(updates) {
   updates = updates.map((update) => ({
     "Update type": update.scope,
     File: update.file,
-    // wrap to 100 chars
     "Current value": truncate(update.from),
     "Proposed change": truncate(update.to),
   }));

--- a/scripts/powerup.js
+++ b/scripts/powerup.js
@@ -33,12 +33,12 @@ async function powerup() {
   if (updates.length > 0) {
     showUpdates(updates);
     const confirmation = await getUserConfirmation(
-      "Do you want to upgrade these file(s) to the latest version?"
+      "Do you want to upgrade these file(s) to the latest Solidity version?"
     );
     if (confirmation) applyUpdates(updates);
   } else {
     console.log(
-      `🎉 soledge is on the latest Solidity version (${LATEST_SOLIDITY_VERSION})!`
+      `🎉 All files are already on the latest Solidity version (${LATEST_SOLIDITY_VERSION})!`
     );
   }
 }

--- a/scripts/powerup.js
+++ b/scripts/powerup.js
@@ -1,0 +1,100 @@
+const fs = require("fs");
+const path = require("path");
+
+/*«-«-«-«-«-«-«-«-«-«-«-«-«-«-«-«-«-«-«-«-«-«-«-«-«-«-«-«-«-«-*/
+/*                          CONFIGS                           */
+/*-»-»-»-»-»-»-»-»-»-»-»-»-»-»-»-»-»-»-»-»-»-»-»-»-»-»-»-»-»-»*/
+
+const LATEST_SOLIDITY_VERSION = "0.8.24";
+const SRC_DIR = "src";
+
+/**
+ * Powerup: Updates solidity version to `LATEST_SOLIDITY_VERSION`.
+ * @param directory The directory containing solidity files.
+ */
+async function powerup() {
+  const updates = [];
+
+  for (let filePath of solidityFiles()) {
+    const oldVersion = getSolidityVersion(filePath);
+    if (!oldVersion) {
+      console.log(`Could not determine Solidity version in ${filePath}`);
+      continue;
+    }
+
+    if (oldVersion != LATEST_SOLIDITY_VERSION) {
+      updates.push({
+        file: filePath,
+        current: oldVersion,
+        latest: LATEST_SOLIDITY_VERSION,
+      });
+    }
+  }
+
+  if (updates.length > 0) {
+    console.log(`${updates.length} file(s) are out of date:`);
+    console.table(updates);
+    const confirmation = await getUserConfirmation();
+    if (confirmation) applyUpdates(updates);
+  } else {
+    console.log(
+      "🎉 All your soledge files are on the latest solidity version!"
+    );
+  }
+}
+
+/*«-«-«-«-«-«-«-«-«-«-«-«-«-«-«-«-«-«-«-«-«-«-«-«-«-«-«-«-«-«-*/
+/*                          Helpers                           */
+/*-»-»-»-»-»-»-»-»-»-»-»-»-»-»-»-»-»-»-»-»-»-»-»-»-»-»-»-»-»-»*/
+
+function solidityFiles(directory = SRC_DIR, fileList = []) {
+  const files = fs.readdirSync(directory);
+
+  files.forEach((file) => {
+    const filePath = path.join(directory, file);
+
+    if (fs.statSync(filePath).isDirectory()) {
+      solidityFiles(filePath, fileList);
+    } else if (file.endsWith(".sol")) {
+      fileList.push(filePath);
+    }
+  });
+  return fileList;
+}
+
+async function getUserConfirmation() {
+  const rl = require("readline").createInterface({
+    input: process.stdin,
+    output: process.stdout,
+  });
+
+  const answer = await new Promise((resolve) => {
+    rl.question(
+      "Do you want to update to the latest version? (y/n): ",
+      resolve
+    );
+  });
+  rl.close();
+  return answer.toLowerCase() === "y";
+}
+
+function applyUpdates(updates) {
+  updates.forEach((update) => {
+    let content = fs.readFileSync(update.file, "utf-8");
+    content = content.replace(new RegExp(update.current, "g"), update.latest);
+    fs.writeFileSync(update.file, content, "utf-8");
+    console.log(
+      `Updated Solidity version in ${update.file} from ${update.current} to ${update.latest}`
+    );
+  });
+  console.log("🎉 Powerup complete!");
+}
+
+function getSolidityVersion(filePath) {
+  const content = fs.readFileSync(filePath, "utf-8");
+  const versionMatch = content.match(/pragma solidity (\^)?(\d+\.\d+\.\d+);/);
+
+  return versionMatch ? versionMatch[2] : null;
+}
+
+powerup();

--- a/scripts/rebrand.js
+++ b/scripts/rebrand.js
@@ -1,0 +1,63 @@
+const fs = require("fs");
+const {
+  getSolidityFiles,
+  showUpdates,
+  getUserConfirmation,
+  applyUpdates,
+} = require("./io");
+
+/**
+ * Rebrand: Migrate branding from solady to soledge.
+ * Currently, only comments are being rebranded.
+ */
+async function rebrand() {
+  const updates = [];
+  const COMMENT_MAPPING = [
+    {
+      from: "/*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/",
+      to: "/*«-«-«-«-«-«-«-«-«-«-«-«-«-«-«-«-«-«-«-«-«-«-«-«-«-«-«-«-«-«-*/",
+    },
+    {
+      from: "/*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/",
+      to: "/*-»-»-»-»-»-»-»-»-»-»-»-»-»-»-»-»-»-»-»-»-»-»-»-»-»-»-»-»-»-»*/",
+    },
+  ];
+
+  for (let filePath of getSolidityFiles()) {
+    for (let patch of COMMENT_MAPPING) {
+      if (fileContainsPattern(filePath, patch.from)) {
+        updates.push({
+          scope: "soledge branding",
+          file: filePath,
+          from: patch.from,
+          to: patch.to,
+        });
+      }
+    }
+  }
+
+  if (updates.length > 0) {
+    showUpdates(updates);
+    const confirmation = await getUserConfirmation(
+      "Do you apply these proposed rebranding (all occurances)?"
+    );
+    if (confirmation) applyUpdates(updates);
+  } else {
+    console.log(`🎉 All files already adheres to soledge branding guidelines.`);
+  }
+}
+
+function fileContainsPattern(filePath, pattern) {
+  const content = fs.readFileSync(filePath, "utf-8");
+
+  // Escape regex special characters from pattern
+  pattern = pattern.replace(/[-[\]{}()*+?.,\\^$|#\s]/g, "\\$&");
+
+  // Use the escaped pattern in the regex match
+  const regex = new RegExp(pattern);
+
+  // Check if the content matches the pattern
+  return regex.test(content);
+}
+
+rebrand();

--- a/scripts/rebrand.js
+++ b/scripts/rebrand.js
@@ -39,7 +39,7 @@ async function rebrand() {
   if (updates.length > 0) {
     showUpdates(updates);
     const confirmation = await getUserConfirmation(
-      "Do you apply these proposed rebranding (all occurances)?"
+      "Confirm applying the proposed branding updates?"
     );
     if (confirmation) applyUpdates(updates);
   } else {


### PR DESCRIPTION
## Description

Closes #11. Introduces an optional scripts to help migrate Solady content to Soledge. Offers previews and requires user confirmation before updating. Includes a reminder to double-check before committing. No external dependency.

## Usage
```
npm run powerup
```
![Screenshot from 2024-02-02 18-37-44](https://github.com/Vectorized/soledge/assets/10168946/f4ffedb0-02d5-4f39-b428-8d02031ff9a6)


```
npm run rebrand
```
![Screenshot from 2024-02-02 18-33-41](https://github.com/Vectorized/soledge/assets/10168946/395d73c2-83ce-4fda-b475-5e13fa1dc0cf)

## Updates
- Following files added to `scripts`:
  ```
  utils
  ├─ config.js — "All script configuration, prime one being the latest supported solidity version."
  ├─ io.js — "Util script for I/O operations"
  ├─ powerup.js - "An assistive file to quickly update solidity version"
  └─ rebrand.js - "An assistive file for rebranding from solady to soledge"
  ```